### PR TITLE
Change linq requirement to 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.4.0",
         "symfony/dom-crawler": ">=2.5.0",
         "symfony/css-selector": ">=2.5.0",
-        "fusonic/linq": "dev-master",
+        "fusonic/linq": "~1.0",
         "guzzlehttp/guzzle": ">=4.0.0"
     },
     "autoload": {


### PR DESCRIPTION
Means that the library can be used if minimum-stability is stable.