### PR TITLE
[PATCH] Add missing title tag.

### DIFF
--- a/src/Objects/ObjectBase.php
+++ b/src/Objects/ObjectBase.php
@@ -316,6 +316,10 @@ abstract class ObjectBase
         foreach ($this->audios as $audio) {
             $properties = array_merge($properties, $audio->getProperties());
         }
+        
+        if ($this->title !== null) {
+            $properties[] = new Property(Property::TITLE, $this->title);
+        }
 
         if ($this->description !== null) {
             $properties[] = new Property(Property::DESCRIPTION, $this->description);


### PR DESCRIPTION
Hello!

Nice library! The patch adds the missing "og:title" that a lot of websites complain about. The title was already being processed but it was not being published with the Publisher(). With the patch it now does.

Please apply if useful.

Regards,
Eva