### PR TITLE
Fixed crawling UTF-8 websites.

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -82,7 +82,8 @@ class Consumer
 
     private function extractOpenGraphData($content)
     {
-        $crawler = new Crawler($content);
+        $crawler = new Crawler;
+        $crawler->addHTMLContent($content, 'UTF-8');
 
         $properties = [];
         foreach(['name', 'property'] as $t)


### PR DESCRIPTION
By default, Symphony assumes websites to be ISO-8859-1.