### PR TITLE
Fallback to link[rel='canonical'] if og:title does not exist

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -119,6 +119,14 @@ class Consumer
         // Assign all properties to the object
         $object->assignProperties($properties, $this->debug);
 
+        // Fallback for url
+        if ($this->useFallbackMode && !$object->url) {
+            $urlElement = $crawler->filter("link[rel='canonical']")->first();
+            if ($urlElement->count()) {
+                $object->url = trim($urlElement->attr("href"));
+            }
+        }
+
         // Fallback for title
         if ($this->useFallbackMode && !$object->title) {
             $titleElement = $crawler->filter("title")->first();

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -99,6 +99,32 @@ LONG;
     }
 
     /**
+     * Checks crawler to correctly use fallback elements when activated.
+     */
+    public function testLoadHtmlCanonicalLinkFallbacksOn()
+    {
+        $content = <<<LONG
+<html>
+<head>
+<title>Title</title>
+<meta property="description" content="Description">
+<link rel="canonical" href="https://github.com/fusonic/opengraph">
+</head>
+<body></body>
+</html>
+LONG;
+
+        $consumer = new Consumer();
+        $consumer->useFallbackMode = true;
+
+        $res = $consumer->loadHtml($content, "about:blank");
+
+        $this->assertEquals("Description", $res->description);
+        $this->assertEquals("Title", $res->title);
+        $this->assertEquals("https://github.com/fusonic/opengraph", $res->url);
+    }
+
+    /**
      * Checks crawler to handle arrays of elements with child-properties like described in the
      * Open Graph documentation (http://ogp.me/#array).
      */


### PR DESCRIPTION
Currently if `og:url` meta tag doesn't exists, the library falls back to the user's url directly. 

Instead, falling back the the `link[rel=canonical]` before the user's url makes more sense.