### PR TITLE
Symfony 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-dom": "*",
-        "symfony/dom-crawler": "^3.0|^4.0|^5.0|^6.0",
-        "symfony/css-selector": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/dom-crawler": "^3.0|^4.0|^5.0|^6.0|^7.0",
+        "symfony/css-selector": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     },


### PR DESCRIPTION
Symfony 7 does require PHP 8.2+ but harmless to be still supporting old PHP versions when on old symfony
Drupal 11 does require Symfony 7/PHP 8.2+ 